### PR TITLE
Output more data to CSV from Usagi scan

### DIFF
--- a/src/org/ohdsi/usagi/WriteCodeMappingsToFile.java
+++ b/src/org/ohdsi/usagi/WriteCodeMappingsToFile.java
@@ -42,8 +42,18 @@ public class WriteCodeMappingsToFile {
 			Row row = codeMapping.sourceCode.toRow();
 			row.add("matchScore", codeMapping.matchScore);
 			row.add("mappingStatus", codeMapping.mappingStatus.toString());
-			row.add("conceptId", targetConcept.conceptId);
-			row.add("comment", codeMapping.comment);
+			row.add("targetConceptId", targetConcept.conceptId);
+			row.add("targetConceptName", targetConcept.conceptName);
+			row.add("targetVocabularyId", targetConcept.vocabularyId);
+			row.add("targetDomainId", targetConcept.domainId);
+			row.add("targetStandardConcept", targetConcept.standardConcept);
+			row.add("targetChildCount", targetConcept.childCount);
+			row.add("targetParentCount", targetConcept.parentCount);
+			row.add("targetConceptClassId", targetConcept.conceptClassId);
+			row.add("targetConceptCode", targetConcept.conceptCode);
+			row.add("targetValidStartDate", targetConcept.validStartDate);
+			row.add("targetValidEndDate", targetConcept.validEndDate);
+			row.add("targetInvalidReason", targetConcept.invalidReason);
 			out.write(row);
 		}
 	}


### PR DESCRIPTION
Quick update to write more information out from a Usagi scan. Now outputs the domain and class alongside the mapped conceptID. Also returns information on whether concepts are standard and valid.